### PR TITLE
#159236216 Enable social logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 # External Libraries
 wger/core/static/bower_components
 node_modules
+package-lock.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ python-decouple==3.1
 dj-database-url==0.5.0
 psycopg2-binary==2.7.5
 whitenoise==3.3.1
+social-auth-app-django==2.1.0
 
 # REST API
 djangorestframework>=3.2,<3.3

--- a/wger/core/static/css/workout-manager.css
+++ b/wger/core/static/css/workout-manager.css
@@ -33,6 +33,9 @@
     background-color: #FFF;
 }
 
+.social-btn {
+    margin-top: 20px;
+}
 
 /*
  * Images in links are vertically aligned
@@ -124,7 +127,7 @@ a:hover img
     -webkit-filter: grayscale(0%);
     -moz-filter: grayscale(0%);
     -ms-filter: grayscale(0%);
-    -o-filter: grayscale(0%);	
+    -o-filter: grayscale(0%);
 }
 */
 
@@ -172,7 +175,7 @@ header h1{
 }
 
 header a,
-header a:hover, 
+header a:hover,
 header a:focus{
     color:white;
     font-size:90%;

--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -14,6 +14,18 @@
     {% trans 'Login' as submit_text %}
     {% render_form_fields form submit_text %}
 </form>
+<div class="row col-md-offset-3 col-md-9">
+    <div class="col-md-4">
+        <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'twitter' %}"> <i class="fa fa-twitter"></i> Login with Twitter</a>
+    </div>
+    <div class="col-md-4">
+        <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'facebook' %}"> <i class="fa fa-facebook"></i> Login with Facebook</a>
+    </div>
+    <div class="col-md-4">
+        <a class="btn btn-danger social-btn" href="{% url 'social:begin' 'google-oauth2' %}"> <i class="fa fa-google"></i> Login with Google</a>
+    </div>
+</div>
+
 {% endblock %}
 
 

--- a/wger/settings_global.py
+++ b/wger/settings_global.py
@@ -90,6 +90,9 @@ INSTALLED_APPS = (
 
     # django-bower for installing bower packages
     'djangobower',
+
+    # socail logins
+    'social_django'
 )
 
 # added list of external libraries to be installed by bower
@@ -131,10 +134,19 @@ MIDDLEWARE_CLASSES = (
     # Django mobile
     'django_mobile.middleware.MobileDetectionMiddleware',
     'django_mobile.middleware.SetFlavourMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware'
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+
+    # socail logins
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 )
 
 AUTHENTICATION_BACKENDS = (
+    # social authentications
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.google.GoogleOAuth',
+    'social_core.backends.twitter.TwitterOAuth',
+    'social_core.backends.facebook.FacebookOAuth2',
+
     'django.contrib.auth.backends.ModelBackend',
     'wger.utils.helpers.EmailAuthBackend'
 )
@@ -160,7 +172,11 @@ TEMPLATES = [
                 'django_mobile.context_processors.flavour',
 
                 # Breadcrumbs
-                'django.template.context_processors.request'
+                'django.template.context_processors.request',
+
+                # social logins
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
             ],
             'loaders': [
                 # Django mobile
@@ -385,3 +401,9 @@ WGER_SETTINGS = {
 
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get('SOCIAL_AUTH_TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get('SOCIAL_AUTH_TWITTER_SECRET')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -241,6 +241,7 @@ urlpatterns += [
         nutrition_api_views.search,
         name='ingredient-search'),
     url(r'^api/v2/', include(router.urls)),
+    url(r'^oauth/', include('social_django.urls', namespace='social')),
 ]
 
 #


### PR DESCRIPTION
#### What does this PR do?
This PR allows a user to login with their pre-existing social media account.
#### Description of Task to be completed?
- Enable login with facebook, twitter and google.
#### How should this be manually tested?
- Pull the branch `ft-enable-social-logins-159236216`
- Install requirements `pip install -r requirements.txt`
- set the following environment variables `SOCIAL_AUTH_FACEBOOK_KEY` `SOCIAL_AUTH_FACEBOOK_SECRET` `SOCIAL_AUTH_TWITTER_KEY` `SOCIAL_AUTH_TWITTER_SECRET` `SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET` `SOCIAL_AUTH_GOOGLE_OAUTH2_KEY` Note these will be shared for development.
- Run migrations `python manage.py migrate`
- Run the app `python manage.py runserver` and ensure to use `localhost:8000` and not `127.0.0.1:8000` Please note the port must be `8000`
- The facebook account to use to test must be specified, currently only my facebook can be used looking for a way I can add team's accounts 
#### What are the relevant pivotal tracker stories?
[#159236216](https://www.pivotaltracker.com/story/show/159236216)
#### Screenshots (if appropriate)
<img width="1439" alt="screen shot 2018-08-02 at 12 23 09" src="https://user-images.githubusercontent.com/23418080/43575223-f63a9272-964e-11e8-8a63-e84a8c6e55e1.png">
<img width="1400" alt="screen shot 2018-08-01 at 15 41 34" src="https://user-images.githubusercontent.com/23418080/43522400-ec688a90-95a1-11e8-8237-524f3248a5d8.png">
<img width="1395" alt="screen shot 2018-08-01 at 15 42 06" src="https://user-images.githubusercontent.com/23418080/43522409-f1dee014-95a1-11e8-9964-646ae65184f1.png">