### PR TITLE
#159236216 Fix margins between social login buttons

### DIFF
--- a/wger/core/static/css/workout-manager.css
+++ b/wger/core/static/css/workout-manager.css
@@ -33,8 +33,14 @@
     background-color: #FFF;
 }
 
+.social-logins {
+    display: flex;
+    justify-content: center;
+}
+
 .social-btn {
     margin-top: 20px;
+    margin-right: 15px;
 }
 
 /*

--- a/wger/core/templates/user/login.html
+++ b/wger/core/templates/user/login.html
@@ -14,16 +14,15 @@
     {% trans 'Login' as submit_text %}
     {% render_form_fields form submit_text %}
 </form>
-<div class="row col-md-offset-3 col-md-9">
-    <div class="col-md-4">
-        <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'twitter' %}"> <i class="fa fa-twitter"></i> Login with Twitter</a>
-    </div>
-    <div class="col-md-4">
-        <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'facebook' %}"> <i class="fa fa-facebook"></i> Login with Facebook</a>
-    </div>
-    <div class="col-md-4">
-        <a class="btn btn-danger social-btn" href="{% url 'social:begin' 'google-oauth2' %}"> <i class="fa fa-google"></i> Login with Google</a>
-    </div>
+<div class="row col-md-offset-3 social-logins">
+    <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'twitter' %}">
+        <i class="fa fa-twitter"></i> Login with Twitter
+    </a>
+    <a class="btn btn-primary social-btn" href="{% url 'social:begin' 'facebook' %}">
+        <i class="fa fa-facebook"></i> Login with Facebook</a>
+    <a class="btn btn-danger social-btn" href="{% url 'social:begin' 'google-oauth2' %}">
+        <i class="fa fa-google"></i> Login with Google
+    </a>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the margins between social login buttons
#### Description of Task to be completed?
- Make the right margins between social buttons even
#### How should this be manually tested?
- Pull this branch `ft-enable-social-logins-159236216`
- Start the server `python manage.py runserver`
- Visit the login page
#### Screenshots (if appropriate)
<img width="1428" alt="screen shot 2018-08-06 at 01 24 17" src="https://user-images.githubusercontent.com/23418080/43690874-93b9e6a6-991a-11e8-8168-b908b23c593b.png">
