### PR TITLE
#159236201 Exercise cache when deleting muscles

### DIFF
--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -42,10 +42,15 @@ class MuscleListView(ListView):
     '''
     Overview of all muscles and their exercises
     '''
-    model = Muscle
-    queryset = Muscle.objects.all().order_by('-is_front', 'name'),
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
+
+    def get_queryset(self):
+        '''
+        Queryset for updated muscles.
+        '''
+        queryset = Muscle.objects.all().order_by('-is_front', 'name'),
+        return queryset
 
     def get_context_data(self, **kwargs):
         '''
@@ -59,7 +64,7 @@ class MuscleListView(ListView):
 
 
 class MuscleAdminListView(
-        LoginRequiredMixin, PermissionRequiredMixin, MuscleListView):
+        LoginRequiredMixin, PermissionRequiredMixin, ListView):
     '''
     Overview of all muscles, for administration purposes
     '''


### PR DESCRIPTION
#### What does this PR do?
This PR ensures that after deleting a muscle, it does not keep appearing in descriptions, muscle overview and exercises by resetting the cache.

#### Description of Task to be completed?
- After deleting a muscle reset the cache to remove that muscle.
#### How should this be manually tested?
- Check out this branch
- Run the application `python manage.py runserver`
- Navigate to the muscles overview  page`http://localhost:8000/en/exercise/muscle/overview/`
- Choose a muscle to delete e.g `pectoralis major`
- Choose muscles from the drop-down on the `Exercises` tab to navigate to the muscles page `http://localhost:8000/en/exercise/muscle/admin-overview/`
- Delete the muscle you choose e.g `pectoralis major` and navigate back to muscle overview page
Note: That muscle should not appear in the list of muscles on the muscles overview page.
#### Any background context you want to provide?
- Prior to this PR, a user would successfully delete a muscle and it would keep appearing in the descriptions, exercises because it  still exists in the cache.
#### What are the relevant pivotal tracker stories?
[#159236201](https://www.pivotaltracker.com/story/show/159236201)