### PR TITLE
[Feature] Show all exercise information

### DIFF
--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -71,3 +71,39 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Muscle
+
+
+class ExerciseAllInfoSerializer(serializers.ModelSerializer):
+    '''
+    Exercise All Information serializer
+    '''
+    exerciseimage_set = ExerciseImageSerializer(read_only=True, many=True)
+    muscles = MuscleSerializer(read_only=True, many=True)
+    muscles_secondary = MuscleSerializer(read_only=True, many=True)
+    category = ExerciseCategorySerializer(read_only=True)
+    equipment = EquipmentSerializer(read_only=True, many=True)
+    license = serializers.StringRelatedField(read_only=True)
+    language = serializers.StringRelatedField(read_only=True)
+    exercisecomment_set = serializers.StringRelatedField(read_only=True, many=True)
+    exercisecomment_set = serializers.StringRelatedField(read_only=True, many=True)
+
+    class Meta:
+        model = Exercise
+        fields = (
+            'id',
+            'creation_date',
+            'name',
+            'name_original',
+            'uuid',
+            'description',
+            'language',
+            'status',
+            'license',
+            'license_author',
+            'category',
+            'exerciseimage_set',
+            'muscles',
+            'muscles_secondary',
+            'equipment',
+            'exercisecomment_set'
+        )

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -32,7 +32,8 @@ from wger.exercises.api.serializers import (
     ExerciseImageSerializer,
     ExerciseCategorySerializer,
     EquipmentSerializer,
-    ExerciseCommentSerializer
+    ExerciseCommentSerializer,
+    ExerciseAllInfoSerializer
 )
 from wger.exercises.models import (
     Exercise,
@@ -75,6 +76,22 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         # Todo is it right to call set author after save?
         obj.set_author(self.request)
         obj.save()
+
+
+class ExerciseAllInforViewSet(viewsets.ReadOnlyModelViewSet):
+    '''
+    API endpoint for all exercise objects information
+    '''
+    queryset = Exercise.objects.all()
+    serializer_class = ExerciseSerializer
+    permission_classes = (IsAuthenticatedOrReadOnly, )
+    ordering_fields = '__all__'
+
+    @detail_route(methods=["GET"])
+    def info(self, request, pk):
+        infos = Exercise.objects.filter(pk=pk)
+        serializer = ExerciseAllInfoSerializer(infos, many=True)
+        return Response(serializer.data, status=200)
 
 
 @api_view(['GET'])

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -401,6 +401,13 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         self.user_login('test')
         self.search_exercise()
 
+    def test_showing_all_exercise_info(self):
+        '''
+        Tests the exercises details page
+        '''
+        response = self.client.get('/api/v2/exercises/1/info/', format=json)
+        self.assertEqual(response.status_code, 200)
+
 
 class DeleteExercisesTestCase(WorkoutManagerDeleteTestCase):
     '''

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -139,6 +139,10 @@ router.register(
     exercises_api_views.ExerciseViewSet,
     base_name='exercise')
 router.register(
+    r'exercises',
+    exercises_api_views.ExerciseAllInforViewSet,
+    base_name='exercises')
+router.register(
     r'equipment',
     exercises_api_views.EquipmentViewSet,
     base_name='api')


### PR DESCRIPTION
#### What does this PR do?
* Creates a new endpoint that shows all information for an exercise.

#### Description of Task to be completed?
* Apparently the available endpoint for an exercise does not show all the information there is for an exercise.
* This PR creates a new endpoint that ensures that a user can access all the information there is for a particular exercise i.e. fields such muscles, muscles_secondary, equipment, images, category, language, and license are presented in detail.

#### How should this be manually tested?
* Clone the project, ```https://github.com/andela/wg-wits.git```.
* In your terminal, ```cd wg-wits```
* Checkout to the ```ft-exercises-info-endpoint-159236197``` branch.
* In the project directory, create a virtual environment and activate it: run ```virtualenv -p python3 venv-django``` then ```source venv-django/bin/activate```
* Install requirements ```pip install -r requirements_devel.txt```
* Serve the application ```python manage.py runserver```
* In the browser, visit the endpoint for a particular exercise and show its information with, ```http://127.0.0.1:8000/api/v2/exercise/<exerciseID>/info/```
* The exercise information will be presented as in the screenshot below.
* Apparently, most of the exercises do not have images, therefore to have them populated, go ahead and add some images for exercises and that information will also show.

#### What are the relevant pivotal tracker stories?
[#159236197](https://www.pivotaltracker.com/story/show/159236197)

#### Screenshots (if appropriate)

**Exercise Information for exercise 15**
<img width="1285" alt="screen shot 2018-08-08 at 19 59 34" src="https://user-images.githubusercontent.com/39955231/43852414-d345cbe6-9b45-11e8-8ef2-309eb702173c.png">

**Exercise Information for exercise 35**
<img width="1124" alt="screen shot 2018-08-08 at 20 00 12" src="https://user-images.githubusercontent.com/39955231/43852418-d5e9be66-9b45-11e8-98fa-359379e2e46c.png">

