### PR TITLE
#159236196 Cache nutritional plan values

### DIFF
--- a/wger/nutrition/apps.py
+++ b/wger/nutrition/apps.py
@@ -13,10 +13,13 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.apps import AppConfig
 
 
-from wger import get_version
+class NutritionPlanValuesConfig(AppConfig):
+    name = 'wger.nutrition'
+    verbose_name = "NutritionPlan"
 
-VERSION = get_version()
-default_app_config = 'wger.nutrition.apps.NutritionPlanValuesConfig'
+    def ready(self):
+        import wger.nutrition.signals

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,21 @@
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from django.core.cache import cache
+from wger.utils.cache import cache_mapper
+
+
+@receiver(post_save, sender=NutritionPlan)
+@receiver(post_delete, sender=NutritionPlan)
+@receiver(post_delete, sender=MealItem)
+@receiver(post_save, sender=MealItem)
+@receiver(post_save, sender=Meal)
+@receiver(post_delete, sender=Meal)
+def reset_nutrional_plan_canonical(sender, **kwargs):
+    '''
+    Function to send signal
+    '''
+    instance_sender = kwargs['instance']
+    if isinstance(instance_sender, (MealItem, NutritionPlan, Meal)):
+        cache.delete(cache_mapper.get_nutritional_plan_canonical(
+            instance_sender.get_owner_object().id))

--- a/wger/nutrition/tests/test_nutrional_plan_values_canonical.py
+++ b/wger/nutrition/tests/test_nutrional_plan_values_canonical.py
@@ -1,0 +1,54 @@
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+from django.core.cache import cache
+
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+from wger.utils.cache import cache_mapper
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+
+
+class NutritionPlanCacheTestCase(WorkoutManagerTestCase):
+    '''
+    Test case for the NutritionalPlan canonical representation
+    '''
+    def test_nutritional_plan_canonical_form_cache(self):
+        '''
+        Test that the nuttritional plan cache is correctly generated
+        '''
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+    def test_nutritional_plan_canonical_form_cache_save(self):
+        '''
+        Tests the nutritional_plan values cache when saving a nutritional plan
+        '''
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+        nutritional_plan.save()
+        self.assertFalse(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+    def test_nutritional_plan_canonical_form_cache_delete(self):
+        '''
+        Tests the nutrional plan values cache when deleting
+        '''
+        nutritional_plan = NutritionPlan.objects.get(pk=1)
+        nutritional_plan.get_nutritional_values()
+        self.assertTrue(cache.get(cache_mapper.get_nutritional_plan_canonical(1)))
+
+        nutritional_plan.delete()
+        self.assertFalse(cache.get(cache_mapper.get_workout_canonical(1)))

--- a/wger/utils/cache.py
+++ b/wger/utils/cache.py
@@ -66,6 +66,8 @@ class CacheKeyMapper(object):
     EXERCISE_CACHE_KEY_MUSCLE_BG = 'exercise-muscle-bg-{0}'
     INGREDIENT_CACHE_KEY = 'ingredient-{0}'
     WORKOUT_CANONICAL_REPRESENTATION = 'workout-canonical-representation-{0}'
+    NUTRITION_PLAN_VALUES_CANONICAL_REPRESENTATION = 'nutritional-plan-values-canonical-\
+    representation-{0}'
     WORKOUT_LOG_LIST = 'workout-log-hash-{0}'
 
     def get_pk(self, param):
@@ -114,6 +116,12 @@ class CacheKeyMapper(object):
         Return the workout canonical representation
         '''
         return self.WORKOUT_LOG_LIST.format(hash_value)
+
+    def get_nutritional_plan_canonical(self, param):
+        '''
+        Return the nutritional plan canonical representation
+        '''
+        return self.NUTRITION_PLAN_VALUES_CANONICAL_REPRESENTATION.format(self.get_pk(param))
 
 
 cache_mapper = CacheKeyMapper()


### PR DESCRIPTION
#### What does this PR do?
Cache for nutritional plan values.
#### Description of Task to be completed?
Enable caching for nutritional plan values.
Have the cache key deleted every time a  NutritionPlan, Meal, and MealItem is added, edited or deleted.
#### How should this be manually tested?

- Git clone project, `https://github.com/andela/wg-wits`

- Checkout to branch `ft-cache-nutritional-values-159236196`

- Create a virtual environment `virtualenv wg-venv -p python3`

- Activate the virtual environment `source wg-venv/bin/activate`

- Install requirements  `pip install -r requirements_devel.tx`
- Run the application `python manage.py runserver`
- Log in to the application.
- Navigate to the nutrition plan section.
- Add at least 25 nutrition plans.
- Open developer tools and note the time difference between **Normal reload** and **hard reload.**



#### Any background context you want to provide?
- Before this implementation, loading nutritional plans took a longer time than it takes currently.
#### What are the relevant pivotal tracker stories?
[#159236196](https://www.pivotaltracker.com/story/show/159236196)
#### Screenshots (if appropriate)
**Before**
<img width="663" alt="screen shot 2018-08-07 at 14 12 54" src="https://user-images.githubusercontent.com/39955261/43889555-2b6ab1ba-9bcd-11e8-9701-3c0f2a26dd33.png">
**After**
<img width="691" alt="screen shot 2018-08-09 at 12 11 30" src="https://user-images.githubusercontent.com/39955261/43889626-66c7eca0-9bcd-11e8-8800-970184baafc5.png">