### PR TITLE
 #159236214 Fix a redirect bug.

### DIFF
--- a/wger/gym/views/gym.py
+++ b/wger/gym/views/gym.py
@@ -184,12 +184,13 @@ def delete_user(request, user_pk):
         member = User.objects.filter(pk=user_pk).first()
         member.delete()
 
-    return HttpResponseRedirect(reverse("gym:gym:user-list", kwargs={'pk': user.pk}))
+    return HttpResponseRedirect(reverse("gym:gym:user-list", kwargs={'pk': user_matched.gym_id}))
 
 
 @login_required()
 def activate_user(request, user_pk):
     member = get_object_or_404(User, pk=user_pk)
+
     user = request.user
     set_status = str(request.GET['active'])
 
@@ -206,7 +207,7 @@ def activate_user(request, user_pk):
         member.is_active = status
         member.save()
 
-    return HttpResponseRedirect(reverse("gym:gym:user-list", kwargs={'pk': user.pk}))
+    return HttpResponseRedirect(reverse("gym:gym:user-list", kwargs={'pk': user_matched.gym_id}))
 
 
 @login_required


### PR DESCRIPTION
#### What does this PR do?
* Fixes a redirect bug
#### Description of Task to be completed?
* Fix the redirect bug that occurs due to the reference Gym id not being found in the database
#### How should this be manually tested?
-  Clone this [branch](https://github.com/andela/wg-wits/tree/ft-allow-deleting-trainers-159236214) and follow the instructions stated in [README](https://github.com/andela/wg-wits/tree/ft-allow-deleting-trainers-159236214) to set up the application.
- After setting up the application, start the server by running the command `python manage.py runserver` in the terminal with your virtual environment set.
- In the browser, log in as an Admin and go to the `gyms` page. As an admin or a gym manager, you should be able to delete, deactivate and re-activate users as shown in the screenshots section.
#### Screenshots 
<img width="1415" alt="screen shot 2018-08-10 at 10 34 37" src="https://user-images.githubusercontent.com/39955305/43944868-1343a01c-9c89-11e8-9993-35c12d20ff45.png">
