### PR TITLE
[Bug] Fix typos exercise all information endpoint

### DIFF
--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -78,7 +78,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         obj.save()
 
 
-class ExerciseAllInforViewSet(viewsets.ReadOnlyModelViewSet):
+class ExerciseAllInformationViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for all exercise objects information
     '''

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -140,7 +140,7 @@ router.register(
     base_name='exercise')
 router.register(
     r'exercises',
-    exercises_api_views.ExerciseAllInforViewSet,
+    exercises_api_views.ExerciseAllInformationViewSet,
     base_name='exercises')
 router.register(
     r'equipment',


### PR DESCRIPTION
#### What does this PR do?
* Fixes a typo on exercise all information endpoint.

#### Description of Task to be completed?
* The endpoint title has a typo and this is replaced with a correct one.
* The breadcrumbs on the endpoint have a typo as well and this is corrected.

#### How should this be manually tested?
* Clone the project, ```https://github.com/andela/wg-wits.git```.
* In your terminal, ```cd wg-wits```
* Checkout to the ```bg-fix-exercises-endpoint-typo-159236197``` branch.
* In the project directory, create a virtual environment and activate it: run ```virtualenv -p python3 venv-django``` then ```source venv-django/bin/activate```
* Install requirements ```pip install -r requirements_devel.txt```
* Serve the application ```python manage.py runserver```
* In the browser, visit the endpoint for a particular exercise and show its information with, ```http://127.0.0.1:8000/api/v2/exercise/<exerciseID>/info/```
* The exercise information endpoint and the breadcrumb should look like the ones in the image below.

#### What are the relevant pivotal tracker stories?
[#159236197](https://www.pivotaltracker.com/story/show/159236197)

#### Screenshots (if appropriate)

**Title and breadcrumbs for the exercise information endpoint.**
<img width="849" alt="screen shot 2018-08-10 at 12 51 40" src="https://user-images.githubusercontent.com/39955231/43952010-5333f640-9c9d-11e8-98b7-07a0f446c2cb.png">
