### PR TITLE
#159236202 Filter Exercise and Ingredient translations better

### DIFF
--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -58,6 +58,7 @@ from wger.utils.widgets import (
     TranslatedOriginalSelectMultiple
 )
 from wger.config.models import LanguageConfig
+from wger.config.models import Language
 from wger.weight.helpers import process_log_entries
 
 
@@ -77,7 +78,10 @@ class ExerciseListView(ListView):
         '''
         Filter to only active exercises in the configured languages
         '''
-        languages = load_item_languages(LanguageConfig.SHOW_ITEM_EXERCISES)
+        url = self.request.META['PATH_INFO']
+        lang_name = url[1:3]
+        languages = Language.objects.filter(short_name=lang_name)
+
         return Exercise.objects.accepted() \
             .filter(language__in=languages) \
             .order_by('category__id') \

--- a/wger/nutrition/views/ingredient.py
+++ b/wger/nutrition/views/ingredient.py
@@ -40,7 +40,7 @@ from wger.utils.generic_views import (
 from wger.utils.constants import PAGINATION_OBJECTS_PER_PAGE
 from wger.utils.language import load_language, load_ingredient_languages
 from wger.utils.cache import cache_mapper
-
+from wger.config.models import Language
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,9 @@ class IngredientListView(ListView):
         (the user can also want to see ingredients in English, in addition to his
         native language, see load_ingredient_languages)
         '''
-        languages = load_ingredient_languages(self.request)
+        url = self.request.META['PATH_INFO']
+        lang_name = url[1:3]
+        languages = Language.objects.filter(short_name=lang_name)
         return (Ingredient.objects.filter(language__in=languages)
                                   .filter(status__in=Ingredient.INGREDIENT_STATUS_OK)
                                   .only('id', 'name'))


### PR DESCRIPTION
#### What does this PR do?
- This PR allows the translations of Exercises and Ingredients better. Initially, say for exercises, only those that were registered in English were shown regardless of the language selected, but now that's not the case, each selected language comes with its own exercises in that language.
#### How should this be manually tested?
- Clone this application as described in the README.
- Under the projects directory, `git checkout ft-trans-ex-ingrdient-159236202`
- After logging in visit the endpoint `http://127.0.0.1:8000/en/exercise/overview/` and change the language to any of your choice, the exercises should change accordingly.
- Visiting the endpoint `http://127.0.0.1:8000/en/nutrition/ingredient/overview/` and changing the language behaves like explained above too. The displayed ingredients are of the selected languages.
#### Relevant PT story
- [#159236199](https://www.pivotaltracker.com/story/show/159236202)