### PR TITLE
[Feature #159236206] Move away from proprietary software Transifex.

### DIFF
--- a/wger/core/templates/navigation.html
+++ b/wger/core/templates/navigation.html
@@ -143,9 +143,9 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                                    <a href="https://translate.zanata.org/iteration/view/wger-wits-trans-20180829/v1">
                                         <span class="fa fa-external-link" aria-hidden="true"></span>
-                                        {% trans "Translate with Transifex" %}
+                                        {% trans "Translate with Zanata" %}
                                     </a>
                                 </li>
                             </ul>

--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -127,7 +127,7 @@
                         {% endfor %}
                         <li class="divider"></li>
                         <li>
-                            <a href="https://www.transifex.com/rge/wger-workout-manager/">
+                            <a href="https://translate.zanata.org/iteration/view/wger-wits-trans-20180829/v1">
                                 <span class="{% fa_class 'plus' %}"></span>
                                 {% trans "Translate" %}
                             </a>

--- a/wger/core/templates/template_features.html
+++ b/wger/core/templates/template_features.html
@@ -96,7 +96,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.transifex.com/rge/wger-workout-manager/" title="{% trans 'Translate' %}">
+                        <a href="https://translate.zanata.org/iteration/view/wger-wits-trans-20180829/v1" title="{% trans 'Translate' %}">
                             <span class="{% fa_class 'globe' %}"></span>
                         </a>
                     </li>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+  <url>https://translate.zanata.org/</url>
+  <project>wger-wits-trans-20180829</project>
+  <project-version>v1</project-version>
+  <project-type>gettext</project-type>
+
+</config>


### PR DESCRIPTION
#### What does this PR do?
- Enable translation using the non-proprietary software Zanata.
#### Description of Task to be completed?
- Modify UI to enable Wger users to access the Zanata Wger translation site.
- Created and setup the Zanata Wger Translation project.
#### How should this be manually tested?
-  Clone this [branch](https://github.com/andela/wg-wits/tree/ft-translation-away-from-transifex-159236206) and follow the instructions stated in [README](https://github.com/andela/wg-wits/tree/ft-translation-away-from-transifex-159236206) to set up the application.
- After setting up the application, start the server by running the command `python manage.py runserver` in the terminal with your virtual environment set.
- In the browser, log in and click on the `about this software` tab in the navigation bar.
- Select the option `Translate with Zanata` in order to access the Translation page. This same page can be accessed [here](https://translate.zanata.org/iteration/view/wger-wits-trans-20180829/v1/languages/gl?dswid=5354).
- Log in or sign up to Zanata. You can follow [this guide](http://docs.zanata.org/en/release/user-guide/account/account-sign-up/#signing-up) to signup.
- Up accessing the translation page, you can then choose a language and [contribute to Translation](http://docs.zanata.org/en/release/user-guide/translator-guide/) .

#### What are the relevant pivotal tracker stories?
[159236206](https://www.pivotaltracker.com/story/show/159236206)

#### Screenshots
<img width="1354" alt="screen shot 2018-08-29 at 14 45 25" src="https://user-images.githubusercontent.com/39955305/44785698-7cafa800-ab9a-11e8-841c-bcc6203b36fb.png">

The Zanata translation page after successful login
<img width="1435" alt="screen shot 2018-08-29 at 14 46 11" src="https://user-images.githubusercontent.com/39955305/44785707-8802d380-ab9a-11e8-984a-54096261c3d5.png">


