### PR TITLE
#160057885 Re-implement skipped test

### DIFF
--- a/wger/core/tests/base_testcase.py
+++ b/wger/core/tests/base_testcase.py
@@ -429,7 +429,7 @@ class WorkoutManagerAddTestCase(WorkoutManagerTestCase):
     pk_after = None
     anonymous_fail = True
     data = {}
-    data_ignore = ()
+    data_ignore = ('ingredient', 'amount',)
     fileupload = None
     '''
     If the form requires a file upload, specify the field name and the file path

--- a/wger/nutrition/tests/test_bmi.py
+++ b/wger/nutrition/tests/test_bmi.py
@@ -117,3 +117,22 @@ class BmiTestCase(WorkoutManagerTestCase):
         entry = WeightEntry.objects.filter(user=user).latest()
         self.assertEqual(entry.weight, 80)
         self.assertEqual(entry.date, datetime.date.today())
+
+    def test_chart_data_with_metrics(self):
+        self.user_login('test')
+        response = self.client.get(reverse('nutrition:bmi:chart-data'))
+        self.assertEqual(response.status_code, 200)
+        data = response.content.decode('utf-8')
+        content = json.loads(data)
+        self.assertEqual(content[0]['weight'], 30)
+
+    def test_chart_data_with_no_metrics(self):
+        self.user_login('admin')
+        user = User.objects.filter(pk=1).first()
+        user.userprofile.weight_unit = "g"
+        user.userprofile.save()
+        response = self.client.get(reverse('nutrition:bmi:chart-data'))
+        self.assertEqual(response.status_code, 200)
+        data = response.content.decode('utf-8')
+        content = json.loads(data)
+        self.assertEqual(content[0]['weight'], 66.139)

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -24,8 +24,7 @@ from wger.core.tests.base_testcase import (
     WorkoutManagerAddTestCase
 )
 from wger.nutrition.models import Meal
-from wger.nutrition.models import NutritionPlan
-from unittest import skip
+from wger.nutrition.models import NutritionPlan, Ingredient
 
 
 class MealRepresentationTestCase(WorkoutManagerTestCase):
@@ -51,18 +50,41 @@ class EditMealTestCase(WorkoutManagerEditTestCase):
     data = {'time': datetime.time(8, 12)}
 
 
-@skip('Skip pending fixing AddMealTestCase')
 class AddMealTestCase(WorkoutManagerAddTestCase):
     '''
     Tests adding a Meal
     '''
-    # FIXME: update method to cater for new add meal flow in the form
-
     object_class = Meal
     url = reverse('nutrition:meal:add', kwargs={'plan_pk': 4})
-    data = {'time': datetime.time(9, 2)}
+    data = {'time': datetime.time(9, 2), 'ingredient': 5,
+            'amount': 23}
     user_success = 'test'
     user_fail = 'admin'
+
+
+class AddEatenMealTestCase(WorkoutManagerAddTestCase):
+    '''
+    Tests adding an eaten meal
+    '''
+    object_class = Meal
+    url = reverse('nutrition:eaten_meal:add', kwargs={'plan_pk': 4})
+    data = {'time': datetime.time(9, 2), 'ingredient': 5,
+            'amount': 23}
+    user_success = 'test'
+    user_fail = 'admin'
+
+
+class MealTestCase(WorkoutManagerTestCase):
+    def test_delete_meal(self):
+        '''
+        Tests deleting a meal
+        '''
+        self.user_login('test')
+        plan = NutritionPlan.objects.filter(pk=4).first()
+        meal = plan.meal_set.first()
+        url = reverse('nutrition:meal:delete', kwargs={'id': meal.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
 
 
 class PlanOverviewTestCase(WorkoutManagerTestCase):

--- a/wger/nutrition/tests/test_meal_item.py
+++ b/wger/nutrition/tests/test_meal_item.py
@@ -17,8 +17,19 @@ from django.core.urlresolvers import reverse
 
 from wger.core.tests import api_base_test
 from wger.core.tests.base_testcase import WorkoutManagerAddTestCase
-from wger.core.tests.base_testcase import WorkoutManagerEditTestCase
-from wger.nutrition.models import MealItem
+from wger.core.tests.base_testcase import WorkoutManagerEditTestCase, WorkoutManagerTestCase
+from wger.nutrition.models import MealItem, NutritionPlan
+
+
+class MealItemTestCase(WorkoutManagerTestCase):
+    def test_delete_meal_item(self):
+        self.user_login('test')
+        plan = NutritionPlan.objects.filter(pk=4).first()
+        meal = plan.meal_set.first()
+        meal_item = MealItem.objects.filter(meal__id=meal.id).first()
+        url = reverse('nutrition:meal_item:delete', kwargs={'item_id': meal_item.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
 
 
 class EditMealItemUnitTestCase(WorkoutManagerEditTestCase):


### PR DESCRIPTION
#### What does this PR do?
- It reactivates a skipped test.
#### Description of Task to be completed?
- Reactivate tests and update it to be aligned with the new meal-addition workflow.
#### How should this be manually tested?
- Pull this branch `ch-re-implement-skipped-tests-160057885`
- Run the tests `python manage.py test`
#### Any background context you want to provide?
- During the implementation of [#159236210](https://www.pivotaltracker.com/story/show/159236210), a test was skipped due to time constraints. 
#### What are the relevant pivotal tracker stories?
[#160057885](https://www.pivotaltracker.com/story/show/160057885)